### PR TITLE
Configure JSON logger in production.

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -10,5 +10,7 @@ func init() {
 			ForceColors: true,
 		})
 		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetFormatter(&log.JSONFormatter{})
 	}
 }


### PR DESCRIPTION
JSON format allows Stackdriver to take the fields and expose it in the filters.